### PR TITLE
Create pypi_publish.yml

### DIFF
--- a/.github/workflows/pypi_publish.yml
+++ b/.github/workflows/pypi_publish.yml
@@ -1,0 +1,25 @@
+name: Upload to PyPi
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine build
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      run: |
+        python -m build --sdist
+        twine upload dist/*


### PR DESCRIPTION
## Summary
This PR adds a workflow to publish software releases to PYPI. The PYPI_TOKEN secrete needs to be added before this will work correctly.
 
## Acknowledgement
By contributing to this software project, I acknowledge that I have reviewed the [software quality assurance guidelines](XXX) and that my contributions are submitted under the [Revised BSD License](XXX). 
